### PR TITLE
Add musical user announcements

### DIFF
--- a/bottica/bot.py
+++ b/bottica/bot.py
@@ -14,6 +14,7 @@ from discord.mentions import AllowedMentions
 
 from bottica.commands import register_commands
 from bottica.infrastructure.error import atask, event_loop, handle_command_error
+from bottica.infrastructure.help import BotticaHelpCommand
 from bottica.music.cog import Music
 from bottica.response import JEALOUS, REACTIONS
 from bottica.sass import make_sass, should_sass
@@ -29,7 +30,7 @@ _logger = logging.getLogger(__name__)
 
 class Bottica(DiscordBot):
     def __init__(self, command_prefix, **options):
-        super().__init__(command_prefix, **options)
+        super().__init__(command_prefix, help_command=BotticaHelpCommand(), **options)
 
         self.status_reporters: List[Callable[[cmd.Context], Iterable[str]]] = []
         self.notify = False

--- a/bottica/commands.py
+++ b/bottica/commands.py
@@ -1,17 +1,18 @@
 """Standalone commands that don't belong to a particular cog."""
 
 import random
-from typing import Set, Union
+from typing import Annotated, Set, Union
 
 import discord
 from discord.ext import commands as cmd
 
+from bottica.infrastructure.command import Description, command
 from bottica.infrastructure.error import atask
 from bottica.sass import make_sass
 from bottica.version import BOT_VERSION
 
 
-@cmd.command()
+@command()
 async def status(ctx: cmd.Context):
     """Print the bot status."""
     lines = [f"Running version `{BOT_VERSION}`"]
@@ -21,8 +22,8 @@ async def status(ctx: cmd.Context):
     atask(ctx.reply(embed=embed))
 
 
-@cmd.command()
-async def rate(ctx: cmd.Context, user: discord.Member):
+@command()
+async def rate(ctx: cmd.Context, user: Annotated[discord.Member, Description("the user to rate")]):
     """Rate the provided user out of 10."""
     if user.id == 305440304528359424 or user == ctx.bot.user:
         rating = 10
@@ -35,15 +36,25 @@ async def rate(ctx: cmd.Context, user: discord.Member):
     atask(ctx.reply(f"{user.mention} is {rating}/10."))
 
 
-@cmd.command()
-async def roll(ctx: cmd.Context, max_: int = 100):
-    """Select a random number up to provided value or 100."""
-    value = random.randint(1, max_)
-    atask(ctx.reply(f"{value} / {max_}"))
+@command()
+async def roll(
+    ctx: cmd.Context,
+    maximum: Annotated[int, Description("the maximum possible value of the roll")] = 100,
+):
+    """
+    Select a random number up to provided value or 100.
+    """
+    value = random.randint(1, maximum)
+    atask(ctx.reply(f"{value} / {maximum}"))
 
 
-@cmd.command()
-async def choose(ctx: cmd.Context, *mentions: Union[discord.Role, discord.Member]):
+@command()
+async def choose(
+    ctx: cmd.Context,
+    *mentions: Annotated[
+        Union[discord.Role, discord.Member], Description("users or roles to chose from")
+    ],
+):
     """Select a single member from provided mentions."""
     selection_set: Set[discord.Member] = set()
     for mention in mentions:

--- a/bottica/infrastructure/check.py
+++ b/bottica/infrastructure/check.py
@@ -1,0 +1,14 @@
+"""Decorators for filtering command contexts."""
+
+from discord.ext import commands as cmd
+
+from .friendly_error import FriendlyError
+
+
+async def has_guild(ctx: cmd.Context) -> bool:
+    if ctx.guild is None:
+        raise FriendlyError("Sorry, you'll need to say that in a server. :blush:")
+    return True
+
+
+guild_only = cmd.check(has_guild)

--- a/bottica/infrastructure/command.py
+++ b/bottica/infrastructure/command.py
@@ -1,0 +1,59 @@
+"""Customized `command` decorator with additional functionality."""
+
+
+from importlib import import_module
+from typing import Any, Callable, Iterable, Optional, Type, get_type_hints
+
+from discord.ext.commands import Command
+from discord.ext.commands import command as discord_command
+from discord.ext.commands.core import MISSING
+
+
+class Description:
+    """Description of a command parameter that can be used in conjunction with typing.Annotated."""
+
+    __slots__ = ("value",)
+
+    def __init__(self, value: str) -> None:
+        self.value = value
+
+
+# pylint: disable=dangerous-default-value
+def command(
+    name: str = MISSING,
+    cls: Type[Command[Any, ..., Any]] = MISSING,
+    **attrs: Any,
+) -> Any:
+    def parameterized_decorator(func: Callable) -> Command[Any, ..., Any]:
+        command_ = discord_command(name, cls, **attrs)(func)
+        _add_parameter_descriptions(command_, func)
+        return command_
+
+    return parameterized_decorator
+
+
+def _add_parameter_descriptions(command_: Command[Any, ..., Any], func: Callable):
+    hints = get_type_hints(
+        func,
+        globalns=vars(import_module(func.__module__)),
+        include_extras=True,
+    )
+
+    for param_name, hint in hints.items():
+        description = _find_description(getattr(hint, "__metadata__", []))
+        if not description:
+            continue
+
+        param = command_.params.get(param_name)
+        if not param:
+            raise ValueError(f"Parameter '{param_name}' does not exist in {func.__name__}")
+
+        command_.params[param_name] = param.replace(description=description.value)
+
+
+def _find_description(hints: Iterable[object]) -> Optional[Description]:
+    for hint in hints:
+        if isinstance(hint, Description):
+            return hint
+
+    return None

--- a/bottica/infrastructure/config.py
+++ b/bottica/infrastructure/config.py
@@ -10,33 +10,42 @@ from os import path
 from typing import ClassVar, Dict, Type
 
 from bottica.file import GUILD_CONFIG_FOLDER
+from bottica.music.song import SongKey
 
+from .converters import DeferredConverter
 from .validators import Min, MinMax, ValidationError
 
 _logger = logging.getLogger(__name__)
 
 
+def _to_announcements(source: dict) -> Dict[int, SongKey]:
+    return {int(key): (str(val[0]), str(val[1])) for key, val in source.items()}
+
+
 class GuildConfig:
     __instances: ClassVar[Dict[int, GuildConfig]] = {}
-    __fields: ClassVar = ["min_repeat_interval", "max_cached_duration"]
+    __fields: ClassVar = ["min_repeat_interval", "max_cached_duration", "announcements"]
 
     min_repeat_interval: MinMax[int] = MinMax(32, 1, 1024)
     max_cached_duration: Min[int] = Min(600, -1)
-
-    def __new__(cls: Type[GuildConfig], guild_id: int) -> GuildConfig:
-        if config := cls.__instances.get(guild_id):
-            return config
-
-        config = super().__new__(cls)
-        cls.__instances[guild_id] = config
-        return config
+    announcements = DeferredConverter(_to_announcements, dict)
 
     def __init__(self, guild_id: int) -> None:
         self.guild_id = guild_id
-        if path.exists(self.filename):
-            self.load()
 
-        self.save()
+    @classmethod
+    def get(cls: Type[GuildConfig], guild_id: int) -> GuildConfig:
+        config = cls.__instances.get(guild_id)
+        if config is not None:
+            return config
+
+        config = cls(guild_id)
+        if path.exists(config.filename):
+            config.load()
+        config.save()
+
+        cls.__instances[guild_id] = config
+        return config
 
     def load(self) -> None:
         """Load values from a file."""

--- a/bottica/infrastructure/help.py
+++ b/bottica/infrastructure/help.py
@@ -1,0 +1,10 @@
+"""Customized help command."""
+
+from typing import Any
+
+from discord.ext import commands as cmd
+
+
+class BotticaHelpCommand(cmd.DefaultHelpCommand):
+    def get_command_signature(self, command: cmd.Command[Any, ..., Any], /) -> str:
+        return super(cmd.DefaultHelpCommand, self).get_command_signature(command)

--- a/bottica/infrastructure/validators.py
+++ b/bottica/infrastructure/validators.py
@@ -5,7 +5,7 @@ Decriptor-based validators for generic data with static duck-typing support.
 from __future__ import annotations
 
 from abc import ABCMeta, abstractmethod
-from typing import Any, Generic, Protocol, Type, TypeVar, overload
+from typing import Any, Callable, Generic, Protocol, Type, TypeVar, overload
 
 from .friendly_error import FriendlyError
 

--- a/bottica/infrastructure/validators.py
+++ b/bottica/infrastructure/validators.py
@@ -5,7 +5,7 @@ Decriptor-based validators for generic data with static duck-typing support.
 from __future__ import annotations
 
 from abc import ABCMeta, abstractmethod
-from typing import Any, Callable, Generic, Protocol, Type, TypeVar, overload
+from typing import Any, Generic, Protocol, Type, TypeVar, overload
 
 from .friendly_error import FriendlyError
 
@@ -21,7 +21,7 @@ LessThanT = TypeVar("LessThanT", bound=SupportsLT)
 
 
 class ValidationError(FriendlyError):
-    """An error to prevent an invalid configratio value."""
+    """An error to prevent an invalid configuration value."""
 
 
 class Validator(Generic[VarT], metaclass=ABCMeta):

--- a/bottica/music/context.py
+++ b/bottica/music/context.py
@@ -110,7 +110,9 @@ class MusicContext(SelectSong):
     ) -> MusicContext:
         # we know the text channel will get loaded, so hackily ignore invalid state
         mctx = cls(guild, cast(discord.TextChannel, None), None, registry)
-        await restore(mctx.filename, mctx, deserializer_opts={"client": client})
+        task = restore(mctx.filename, mctx, deserializer_opts={"client": client})
+        if task:
+            await task
 
         if mctx._voice_client is not None:
             await mctx.play_next()

--- a/bottica/music/download.py
+++ b/bottica/music/download.py
@@ -63,7 +63,7 @@ async def download_song(song: SongInfo | ReqInfo, keep: bool) -> str:
     return filename
 
 
-async def process_request(query: str) -> Iterable[SongInfo]:
+async def process_request(query: str) -> list[SongInfo]:
     """Process provided query and get the songs it requests in order."""
     req_info = await event_loop.run_in_executor(
         None,
@@ -81,7 +81,7 @@ async def process_request(query: str) -> Iterable[SongInfo]:
     req_type = req_info.get("_type", "video")
 
     if req_type == "playlist":
-        return filter(None, (_extract_song_info(req) for req in req_info["entries"]))
+        return list(filter(None, (_extract_song_info(req) for req in req_info["entries"])))
 
     song_info = _extract_song_info(req_info)
     return [song_info] if song_info else []

--- a/bottica/music/download.py
+++ b/bottica/music/download.py
@@ -2,7 +2,7 @@
 from functools import partial
 from logging import getLogger
 from os import path
-from typing import Iterable, NewType, Optional, cast
+from typing import NewType, Optional, cast
 
 from yt_dlp import YoutubeDL  # type: ignore
 
@@ -57,7 +57,9 @@ async def download_song(song: SongInfo | ReqInfo, keep: bool) -> str:
     task = _download_and_normalize if keep else _download
     atask(task(req))
 
-    filename = path.join(AUDIO_FOLDER, song.filename.replace(f".{SONG_EXTENSION}", f".{req.get('ext', '')}"))
+    filename = path.join(
+        AUDIO_FOLDER, song.filename.replace(f".{SONG_EXTENSION}", f".{req.get('ext', '')}")
+    )
     await file.wait_until_available(filename, 2)
 
     return filename

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+**Announcements**! You can now set a song to play when you enter a channel by calling `b.announcement <song>` ^^
+
+
 ## 0.23.1
 
 ### Improved


### PR DESCRIPTION
# Changes

Adds new **announcement** feature: songs played when a user enter a voice chat. The actual song played is configured on per-user basis.

Effectively solves #9 

## Missing functionality

- [ ] Shortening the songs to just a sound-byte
- [ ] Allowing short announcements to interrupt regular schedule
- [x] Some cleanup
